### PR TITLE
Move dependencies into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,13 @@
 source "https://rubygems.org"
-gemspec
+
+gem "oauth2", ">= 0.5.2"
+gem "faraday", ">= 0.7.4"
+gem "faraday_middleware", ">= 0.7.8"
+gem "hashie", ">= 1.2"
+gem "webmock", ">= 1.7.6"
+
+group :development do
+  gem "shoulda"
+  gem "simplecov"
+  gem "jeweler"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,16 +11,6 @@ Jeweler::Tasks.new do |gem|
   gem.description = "This is a wrapper for RunKeeper Health Graph RESTful API."
   gem.email = "kenny@kennyma.me"
   gem.authors = ["Kenny Ma"]
-
-  gem.add_dependency "oauth2", ">= 0.5.2"
-  gem.add_dependency "faraday", ">= 0.7.4"
-  gem.add_dependency "faraday_middleware", ">= 0.7.8"
-  gem.add_dependency "hashie", ">= 1.2"
-  gem.add_dependency "webmock", ">= 1.7.6"
-
-  gem.add_development_dependency "shoulda"
-  gem.add_development_dependency "simplecov"
-  gem.add_development_dependency "jeweler"
 end
 Jeweler::RubygemsDotOrgTasks.new
 


### PR DESCRIPTION
This commit moves the dependencies out of the jeweler Rakefile and into
the Gemfile. This is due to a bug in the way jeweler is building the
gemspec and creating a circular reference.
