### PR TITLE
Add gemnasium badge

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,8 @@
 
 {<img src="https://travis-ci.org/endoze/health_graph.png?branch=master" />}[https://travis-ci.org/endoze/health_graph]
 
+{<img src="https://gemnasium.com/endoze/health_graph.png" alt="Dependency Status" />}[https://gemnasium.com/endoze/health_graph]
+
 Ruby gem to work with RunKeeper Health Graph API.  More information about RunKeeper Health Graph API http://developer.runkeeper.com/healthgraph.
 
 == Usage


### PR DESCRIPTION
This commit adds a gemnasium badge to the readme. This allows for
developers to see, at a glance, what the status of the projects
dependencies are.
